### PR TITLE
chore: Restrict providers version

### DIFF
--- a/components/cloudhsm/versions.tf
+++ b/components/cloudhsm/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.0.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.64.0, < 6.0.0"
+      version = ">= 4.9.0, < 6.0.0"
     }
   }
 }


### PR DESCRIPTION
CloudPosse's framework does not support AWS provider > 6.0.0